### PR TITLE
croot: remove -m64 and -rdynamic from #cgo LDFLAGS

### DIFF
--- a/gen-croot.go
+++ b/gen-croot.go
@@ -228,5 +228,12 @@ func copyFile(dst, src string) error {
 }
 
 func trim(b []byte) []byte {
-	return bytes.TrimRight(b, "\r\n")
+	o := bytes.TrimRight(b, "\r\n")
+	o = bytes.Replace(o, []byte(" -m64 "), []byte(" "), -1)
+	o = bytes.Replace(o, []byte(" -m64"), []byte(""), -1)
+	o = bytes.Replace(o, []byte("-m64 "), []byte(""), -1)
+	o = bytes.Replace(o, []byte(" -rdynamic "), []byte(" "), -1)
+	o = bytes.Replace(o, []byte(" -rdynamic"), []byte(""), -1)
+	o = bytes.Replace(o, []byte("-rdynamic "), []byte(""), -1)
+	return o
 }


### PR DESCRIPTION
Fixes go-hep/croot#12.